### PR TITLE
streamlining the abstract

### DIFF
--- a/draft-ietf-rtcweb-security.xml
+++ b/draft-ietf-rtcweb-security.xml
@@ -71,19 +71,10 @@
 
     <abstract>
       <t>
-        The Real-Time Communications on the Web (RTCWEB) working group is tasked with
-        standardizing protocols for real-time communications between Web browsers, generally
-        called "WebRTC". The
-        major use cases for WebRTC technology are real-time audio and/or video calls,
-        Web conferencing, and direct data transfer. Unlike most conventional real-time systems
-        (e.g., SIP-based soft phones) WebRTC communications are directly controlled
-        by a Web server, which poses new security challenges.
-        For instance, a Web browser might expose a JavaScript
-        API which allows a server to place a video call. Unrestricted access to such
-        an API would allow any site which a user visited to "bug" a user's computer,
-        capturing any activity which passed in front of their camera. This document
-        defines the WebRTC threat model and analyzes the security threats of
-        WebRTC in that model.
+        WebRTC is a protocol suite for use with real-time applications that can
+        be deployed in browsers - "real time communication on the Web".  This
+        document defines the WebRTC threat model and analyzes the security threats of
+        WebRTC in that model.  
       </t>
     </abstract>
   </front>


### PR DESCRIPTION
I suspect we'll get dinged here for referring to the RTCWEB WG by name.  I'm thinking we can just trim it down to be a one sentence blurb (stolen from overview) and then say this is the threat model/analysis.